### PR TITLE
Only fetch necessary chart data

### DIFF
--- a/app/components/charts/StackedBar.tsx
+++ b/app/components/charts/StackedBar.tsx
@@ -40,7 +40,6 @@ const dataConfig = {
 };
 
 export default (data: any) => {
-  const labelsLimit = 30;
   const chartData = useMemo(() => {
     const internalChartData = cloneDeep(dataConfig);
     // Todo: change dataset generation
@@ -53,9 +52,9 @@ export default (data: any) => {
       internalChartData.datasets.pop();
     }
 
-    internalChartData.labels = data.data.labels.slice(-labelsLimit);
+    internalChartData.labels = data.data.labels;
     internalChartData.datasets.forEach((dataset, index) => {
-      dataset.data = data.data.amounts[index].slice(-labelsLimit);
+      dataset.data = data.data.amounts[index];
       dataset.label = data.data.namedLabels[index];
     });
     return internalChartData;
@@ -69,7 +68,7 @@ export default (data: any) => {
         responsive: true,
         normalized: true,
         scales: {
-          x: { stacked: true, min: 0, max: labelsLimit },
+          x: { stacked: true, min: 0 },
           y: { stacked: true },
         },
         color: "rgb(26, 12, 109)",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,118 +259,150 @@ async function getDashboardData() {
   const rEthTvl = Number(await rEthStrategy.sharesToUnderlyingView(await rEthStrategy.totalShares())) / 1e18;
   const cbEthTvl = Number(await cbEthStrategy.sharesToUnderlyingView(await cbEthStrategy.totalShares())) / 1e18;
 
-  const rEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("DailyRETHDeposits")
-      .select("*")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse() || [];
+  const rEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyRETHDeposits")
+        .select("*")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const stEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("DailyStETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const stEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyStETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cbEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("DailyCbETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cbEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyCbETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeREthDeposits = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyRETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeREthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyRETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeStEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyStETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeStEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyStETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeCbEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyCbETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeCbEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyCbETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const beaconChainEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("DailyBeaconChainETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const beaconChainEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyBeaconChainETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeBeaconChainEthDeposits = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyBeaconChainETHDeposits")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeBeaconChainEthDeposits = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyBeaconChainETHDeposits")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const rEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("DailyRETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const rEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyRETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const stEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("DailyStETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const stEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyStETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cbEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("DailyCbETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cbEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyCbETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeREthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyRETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeREthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyRETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeStEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyStETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeStEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyStETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeCbEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyCbETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeCbEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyCbETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const beaconChainEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("DailyBeaconChainETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const beaconChainEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("DailyBeaconChainETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
-  const cumulativeBeaconChainEthWithdrawals = supabaseUnwrap(
-    await supabase
-      .from("CumulativeDailyBeaconChainETHWithdrawals")
-      .order("date", { ascending: false })
-      .limit(MAX_CHART_SIZE)
-  ).reverse()|| [];
+  const cumulativeBeaconChainEthWithdrawals = (
+    supabaseUnwrap(
+      await supabase
+        .from("CumulativeDailyBeaconChainETHWithdrawals")
+        .order("date", { ascending: false })
+        .limit(MAX_CHART_SIZE)
+    ) || []
+  ).reverse();
 
   const totalStakedBeaconChainEth = supabaseUnwrap(
     await supabase

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ const CBETH_STRATEGY_ADDRESS = "0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc";
 const RETH_STRATEGY_ADDRESS = "0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2";
 const provider = new ethers.JsonRpcProvider("https://rpc.ankr.com/eth");
 const MAX_LEADERBOARD_SIZE = 50;
+const MAX_CHART_SIZE = 30;
 
 export default async function Home() {
   const {
@@ -262,97 +263,114 @@ async function getDashboardData() {
     await supabase
       .from("DailyRETHDeposits")
       .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse() || [];
 
   const stEthDeposits = supabaseUnwrap(
     await supabase
       .from("DailyStETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cbEthDeposits = supabaseUnwrap(
     await supabase
       .from("DailyCbETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeREthDeposits = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyRETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeStEthDeposits = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyStETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeCbEthDeposits = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyCbETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const beaconChainEthDeposits = supabaseUnwrap(
     await supabase
       .from("DailyBeaconChainETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeBeaconChainEthDeposits = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyBeaconChainETHDeposits")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const rEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("DailyRETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const stEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("DailyStETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cbEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("DailyCbETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeREthWithdrawals = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyRETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeStEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyStETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeCbEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyCbETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const beaconChainEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("DailyBeaconChainETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const cumulativeBeaconChainEthWithdrawals = supabaseUnwrap(
     await supabase
       .from("CumulativeDailyBeaconChainETHWithdrawals")
-      .select("*")
-  ) || [];
+      .order("date", { ascending: false })
+      .limit(MAX_CHART_SIZE)
+  ).reverse()|| [];
 
   const totalStakedBeaconChainEth = supabaseUnwrap(
     await supabase

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -273,6 +273,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyStETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -282,6 +283,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyCbETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -291,6 +293,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyRETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -300,6 +303,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyStETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -309,6 +313,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyCbETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -318,6 +323,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyBeaconChainETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -327,6 +333,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyBeaconChainETHDeposits")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -336,6 +343,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyRETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -345,6 +353,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyStETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -354,6 +363,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyCbETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -363,6 +373,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyRETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -372,6 +383,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyStETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -381,6 +393,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyCbETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -390,6 +403,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("DailyBeaconChainETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []
@@ -399,6 +413,7 @@ async function getDashboardData() {
     supabaseUnwrap(
       await supabase
         .from("CumulativeDailyBeaconChainETHWithdrawals")
+        .select("*")
         .order("date", { ascending: false })
         .limit(MAX_CHART_SIZE)
     ) || []


### PR DESCRIPTION
This PR makes it so the chart data is truncated in the query itself, which is not totally necessary with how we're making builds, but it's the ideal approach.