### PR TITLE
Slightly improve wording in deposit chart titles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default async function Home() {
       <div className="staking-dashboard w-full md:w-3/4 lg:w-2/3 2xl:w-1/2">
         <div className="charts-homepage mt-16">
           <h3 className="text-center text-xl">
-            Cumulative deposited tokens by day
+            Cumulative Token Deposits by day
           </h3>
           <div className="chart-2">
             <LineChart
@@ -121,7 +121,7 @@ export default async function Home() {
           </div>
         </div>
         <div className="charts-homepage mt-16">
-          <h3 className="text-center text-xl">Deposited tokens by day</h3>
+          <h3 className="text-center text-xl">Token Deposits by day</h3>
           <div className="chart-staked-lst-date">
             <StackedBar
               data={{


### PR DESCRIPTION
This PR basically just changes "deposited tokens" to "token deposits" in chart titles. This way, it's less confusing when compared to the staked amount, as it can be understood that staked = deposited.