### PR TITLE
Consolidate number formatters

### DIFF
--- a/src/lrt/LRTDistribution.jsx
+++ b/src/lrt/LRTDistribution.jsx
@@ -1,6 +1,11 @@
 import { AreaClosed, AreaStack } from '@visx/shape';
 import { AxisBottom, AxisRight } from '@visx/axis';
-import { colors, fullNumFormatter, protocols } from './helpers';
+import { colors, protocols } from './helpers';
+import {
+  formatIntETH,
+  formatIntUSD,
+  formatShortened
+} from '../shared/formatters';
 import { scaleLinear, scaleUtc } from '@visx/scale';
 import { Tab, Tabs } from '@nextui-org/react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -113,16 +118,9 @@ export default function LRTDistribution({ data, height }) {
       total += last.protocols[p];
     }
 
-    let symbol;
-
-    if (state.useRate) {
-      symbol = '$';
-      total *= last.rate;
-    } else {
-      symbol = 'ETH ';
-    }
-
-    return `${symbol}${fullNumFormatter.format(total)}`;
+    return state.useRate
+      ? formatIntUSD(total * last.rate)
+      : formatIntETH(total);
   }, [data, state.useRate]);
   const getValue = useCallback(
     (d, k) => d.protocols[k] * (state.useRate ? d.rate : 1),
@@ -319,7 +317,7 @@ export default function LRTDistribution({ data, height }) {
               left={state.maxX}
               numTicks={4}
               scale={scaleValue}
-              tickFormat={formatValue}
+              tickFormat={formatShortened}
               tickClassName="[&_line]:stroke-foreground-2"
               tickLabelProps={{
                 className: 'text-xs',
@@ -402,12 +400,14 @@ export default function LRTDistribution({ data, height }) {
                     ></span>
                     {protocols[key]?.name ?? key}
                     <span className="grow ps-4 text-end">
-                      {fullNumFormatter.format(
-                        Number(
-                          tooltipData.data.protocols[key] *
-                            (state.useRate ? tooltipData.data.rate : 1)
-                        )
-                      )}
+                      {state.useRate
+                        ? formatIntUSD(
+                            Number(
+                              tooltipData.data.protocols[key] *
+                                tooltipData.data.rate
+                            )
+                          )
+                        : formatIntETH(Number(tooltipData.data.protocols[key]))}
                     </span>
                   </div>
                 </li>
@@ -434,19 +434,7 @@ const formatDate = date => {
 
   return axisDateFormatter.format(date);
 };
-const formatValue = value => {
-  if (value >= 1e9) {
-    return `${value / 1e9}b`;
-  }
-
-  if (value >= 1e6) {
-    return `${value / 1e6}m`;
-  }
-
-  return `${value / 1e3}k`;
-};
 const getDate = d => new Date(d.timestamp);
-
 const getY0 = d => d[0];
 const getY1 = d => d[1];
 const isDefined = d => !!d[1];

--- a/src/lrt/LRTDistribution.jsx
+++ b/src/lrt/LRTDistribution.jsx
@@ -1,11 +1,7 @@
 import { AreaClosed, AreaStack } from '@visx/shape';
 import { AxisBottom, AxisRight } from '@visx/axis';
 import { colors, protocols } from './helpers';
-import {
-  formatIntETH,
-  formatIntUSD,
-  formatShortened
-} from '../shared/formatters';
+import { formatETH, formatNumber, formatUSD } from '../shared/formatters';
 import { scaleLinear, scaleUtc } from '@visx/scale';
 import { Tab, Tabs } from '@nextui-org/react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -118,9 +114,7 @@ export default function LRTDistribution({ data, height }) {
       total += last.protocols[p];
     }
 
-    return state.useRate
-      ? formatIntUSD(total * last.rate)
-      : formatIntETH(total);
+    return state.useRate ? formatUSD(total * last.rate) : formatETH(total);
   }, [data, state.useRate]);
   const getValue = useCallback(
     (d, k) => d.protocols[k] * (state.useRate ? d.rate : 1),
@@ -317,7 +311,7 @@ export default function LRTDistribution({ data, height }) {
               left={state.maxX}
               numTicks={4}
               scale={scaleValue}
-              tickFormat={formatShortened}
+              tickFormat={v => formatNumber(v, true)}
               tickClassName="[&_line]:stroke-foreground-2"
               tickLabelProps={{
                 className: 'text-xs',
@@ -401,13 +395,13 @@ export default function LRTDistribution({ data, height }) {
                     {protocols[key]?.name ?? key}
                     <span className="grow ps-4 text-end">
                       {state.useRate
-                        ? formatIntUSD(
+                        ? formatUSD(
                             Number(
                               tooltipData.data.protocols[key] *
                                 tooltipData.data.rate
                             )
                           )
-                        : formatIntETH(Number(tooltipData.data.protocols[key]))}
+                        : formatETH(Number(tooltipData.data.protocols[key]))}
                     </span>
                   </div>
                 </li>

--- a/src/lrt/LRTList.jsx
+++ b/src/lrt/LRTList.jsx
@@ -1,4 +1,5 @@
-import { colors, fullNumFormatter, protocols } from './helpers';
+import { colors, protocols } from './helpers';
+import { formatIntETH, formatIntUSD } from '../shared/formatters';
 
 export default function LRTList({ data }) {
   return (
@@ -24,9 +25,9 @@ export default function LRTList({ data }) {
               {protocols[name].name}
             </span>
             <div className="basis-1/3 ps-9 text-end">
-              <div>${fullNumFormatter.format(value * data.rate)}</div>
+              <div>{formatIntUSD(value * data.rate)}</div>
               <div className="text-foreground-1 text-xs">
-                ETH {fullNumFormatter.format(value)}
+                {formatIntETH(value)}
               </div>
             </div>
           </div>

--- a/src/lrt/LRTList.jsx
+++ b/src/lrt/LRTList.jsx
@@ -1,5 +1,5 @@
 import { colors, protocols } from './helpers';
-import { formatIntETH, formatIntUSD } from '../shared/formatters';
+import { formatETH, formatUSD } from '../shared/formatters';
 
 export default function LRTList({ data }) {
   return (
@@ -25,9 +25,9 @@ export default function LRTList({ data }) {
               {protocols[name].name}
             </span>
             <div className="basis-1/3 ps-9 text-end">
-              <div>{formatIntUSD(value * data.rate)}</div>
+              <div>{formatUSD(value * data.rate)}</div>
               <div className="text-foreground-1 text-xs">
-                {formatIntETH(value)}
+                {formatETH(value)}
               </div>
             </div>
           </div>

--- a/src/lrt/LRTTotalValue.jsx
+++ b/src/lrt/LRTTotalValue.jsx
@@ -1,4 +1,4 @@
-import { fullNumFormatter } from './helpers';
+import { formatIntETH, formatIntUSD } from '../shared/formatters';
 import { Skeleton } from '@nextui-org/react';
 
 export default function LRTTotalValue({
@@ -20,13 +20,10 @@ export default function LRTTotalValue({
           {!isLoadingDelegations && (
             <div className="text-center">
               <div className="text-foreground-1 text-sm">
-                $
-                {fullNumFormatter.format(
-                  delegations?.total * delegations?.rate
-                )}
+                {formatIntUSD(delegations?.total * delegations?.rate)}
               </div>
               <div className="text-foreground-2 text-xs">
-                ETH {fullNumFormatter.format(delegations?.total)}
+                {formatIntETH(delegations?.total)}
               </div>
             </div>
           )}

--- a/src/lrt/LRTTotalValue.jsx
+++ b/src/lrt/LRTTotalValue.jsx
@@ -1,4 +1,4 @@
-import { formatIntETH, formatIntUSD } from '../shared/formatters';
+import { formatETH, formatUSD } from '../shared/formatters';
 import { Skeleton } from '@nextui-org/react';
 
 export default function LRTTotalValue({
@@ -20,10 +20,10 @@ export default function LRTTotalValue({
           {!isLoadingDelegations && (
             <div className="text-center">
               <div className="text-foreground-1 text-sm">
-                {formatIntUSD(delegations?.total * delegations?.rate)}
+                {formatUSD(delegations?.total * delegations?.rate)}
               </div>
               <div className="text-foreground-2 text-xs">
-                {formatIntETH(delegations?.total)}
+                {formatETH(delegations?.total)}
               </div>
             </div>
           )}

--- a/src/lrt/helpers.js
+++ b/src/lrt/helpers.js
@@ -36,11 +36,6 @@ export const colors = [
   '#7dd3fc'
 ];
 
-// eslint-disable-next-line no-undef
-export const fullNumFormatter = new Intl.NumberFormat('en-us', {
-  maximumFractionDigits: 0
-});
-
 export const protocols = {
   bedrock: { index: 0, name: 'Bedrock' },
   eigenpie: { index: 6, name: 'Eigenpie' },

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -1,16 +1,16 @@
 /**
- * Formats the given value as a rounded ETH amount.
- * @param {number | bigint} value The value to format.
- * @returns {string} The formatted value.
- */
-export const formatIntETH = value => ethIntFormatter.format(value);
-
-/**
  * Formats the given value as a rounded integer.
  * @param {number | bigint} value The value to format.
  * @returns {string} The formatted value.
  */
 export const formatInt = value => intFormatter.format(value);
+
+/**
+ * Formats the given value as a rounded ETH amount.
+ * @param {number | bigint} value The value to format.
+ * @returns {string} The formatted value.
+ */
+export const formatIntETH = value => ethIntFormatter.format(value);
 
 /**
  * Formats the given value as a rounded USD amount.

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -1,0 +1,58 @@
+/**
+ * Formats the given value as a rounded ETH amount.
+ * @param {number | bigint} value The value to format.
+ * @returns {string} The formatted value.
+ */
+export const formatIntETH = value => ethIntFormatter.format(value);
+
+/**
+ * Formats the given value as a rounded integer.
+ * @param {number | bigint} value The value to format.
+ * @returns {string} The formatted value.
+ */
+export const formatInt = value => intFormatter.format(value);
+
+/**
+ * Formats the given value as a rounded USD amount.
+ * @param {number | bigint} value The value to format.
+ * @returns {string} The formatted value.
+ */
+export const formatIntUSD = value => usdIntFormatter.format(value);
+
+/**
+ * Formats the given number using 'k', 'm', or 'b' notation.
+ * @param {number} value The value to format.
+ * @returns {string} The formatted value.
+ */
+export const formatShortened = value => {
+  if (value >= 1e9) {
+    return `${value / 1e9}b`;
+  }
+
+  if (value >= 1e6) {
+    return `${value / 1e6}m`;
+  }
+
+  return `${value / 1e3}k`;
+};
+
+// eslint-disable-next-line no-undef
+const ethIntFormatter = new Intl.NumberFormat('en-us', {
+  currency: 'ETH',
+  currencyDisplay: 'code',
+  maximumFractionDigits: 0,
+  style: 'currency'
+});
+
+// eslint-disable-next-line no-undef
+const intFormatter = new Intl.NumberFormat('en-us', {
+  maximumFractionDigits: 0
+});
+
+// eslint-disable-next-line no-undef
+const usdIntFormatter = new Intl.NumberFormat('en-us', {
+  currency: 'USD',
+  currencyDisplay: 'symbol',
+  maximumFractionDigits: 0,
+  style: 'currency'
+});

--- a/src/shared/formatters.js
+++ b/src/shared/formatters.js
@@ -1,40 +1,39 @@
 /**
- * Formats the given value as a rounded integer.
- * @param {number | bigint} value The value to format.
- * @returns {string} The formatted value.
- */
-export const formatInt = value => intFormatter.format(value);
-
-/**
  * Formats the given value as a rounded ETH amount.
  * @param {number | bigint} value The value to format.
+ * @param {boolean} compact Whether to use compact notation.
  * @returns {string} The formatted value.
  */
-export const formatIntETH = value => ethIntFormatter.format(value);
+export const formatETH = (value, compact) =>
+  (compact ? ethCompactFormatter : ethIntFormatter).format(value);
+
+/**
+ * Formats the given value as a rounded integer.
+ * @param {number | bigint} value The value to format.
+ * @param {boolean} compact Whether to use compact notation.
+ * @returns {string} The formatted value.
+ */
+export const formatNumber = (value, compact) =>
+  (compact ? numCompactFormatter : numIntFormatter).format(value);
 
 /**
  * Formats the given value as a rounded USD amount.
  * @param {number | bigint} value The value to format.
+ * @param {boolean} compact Whether to use compact notation.
  * @returns {string} The formatted value.
  */
-export const formatIntUSD = value => usdIntFormatter.format(value);
+export const formatUSD = (value, compact) =>
+  (compact ? usdCompactFormatter : usdIntFormatter).format(value);
 
-/**
- * Formats the given number using 'k', 'm', or 'b' notation.
- * @param {number} value The value to format.
- * @returns {string} The formatted value.
- */
-export const formatShortened = value => {
-  if (value >= 1e9) {
-    return `${value / 1e9}b`;
-  }
-
-  if (value >= 1e6) {
-    return `${value / 1e6}m`;
-  }
-
-  return `${value / 1e3}k`;
-};
+// eslint-disable-next-line no-undef
+const ethCompactFormatter = new Intl.NumberFormat('en-us', {
+  currency: 'ETH',
+  currencyDisplay: 'code',
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+  style: 'currency',
+  notation: 'compact'
+});
 
 // eslint-disable-next-line no-undef
 const ethIntFormatter = new Intl.NumberFormat('en-us', {
@@ -45,8 +44,25 @@ const ethIntFormatter = new Intl.NumberFormat('en-us', {
 });
 
 // eslint-disable-next-line no-undef
-const intFormatter = new Intl.NumberFormat('en-us', {
+const numCompactFormatter = new Intl.NumberFormat('en-us', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+  notation: 'compact'
+});
+
+// eslint-disable-next-line no-undef
+const numIntFormatter = new Intl.NumberFormat('en-us', {
   maximumFractionDigits: 0
+});
+
+// eslint-disable-next-line no-undef
+const usdCompactFormatter = new Intl.NumberFormat('en-us', {
+  currency: 'USD',
+  currencyDisplay: 'symbol',
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+  style: 'currency',
+  notation: 'compact'
 });
 
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
Introduced `shared/formatters.js` that contains common number formatters we need:

- USD amount formatted as a rounded integer like $123,456 or compact $1.2B
- ETH amount formatted as a rounded integer like ETH 123,456 or compact like ETH 1.2B
- Number formatted as a rounded integer 123,456 or compact like 1.2B

Updated LRT view to use those.

