### PR TITLE
Migrate manual provisioned Amplify to be managed by terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ dist/
 # misc
 *.DS_Store
 
+# Terraform files
+*.tfstate
+*.tfstate.backup
+*.tfplan
+.terraform/

--- a/terraform/Amplify/.terraform.lock.hcl
+++ b/terraform/Amplify/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.56.1"
+  hashes = [
+    "h1:CIpGByiuO3cCbfyvcmvkF9wrRuIQxjmqkO9c1k8Kx/Q=",
+    "zh:0fff674596251d3f46b5a9e242220871d6c634f7cf69f2741d1c3c8f4baa708c",
+    "zh:1495d0f71bbd849ad286e7afa9d531a45217e6af7e3d165a447809dab364bd9b",
+    "zh:3eab136bd5b6c58a99f5cb588220819c70061b48da98f2b40061ebabfcbe1957",
+    "zh:3faa780ae84db4751d32ce3e7c4797711c9b5c537b67884037f0951a2f93c1ee",
+    "zh:47455bd243986893cc79f3d884633961244faeeef678fd64a37fcc77f3dabe24",
+    "zh:4a26df74f018ea25f3b543e9bc9d5763c7adc0cec647fc1cb1acec47cc331953",
+    "zh:592cebca964f297f569dc86e99789bfcc301904a9c26cd7294dab99e106acf59",
+    "zh:75d5ed50f1f56c484f7fcb1bd1c4ad33e2679ed249cc8db05e561233f8f5781f",
+    "zh:7ec8cce722a91ba141a3b2db0e833acc3be91e4eec6abb41f012bc9d641ca24e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cba68f518f794e695b0448be4ff90906a7817f65ca5e4d987720e37fbeea7c90",
+    "zh:e29712ab48d6527253ae4aef3851bd8e831b7b0bb57b5097bef16cbb69af6e85",
+    "zh:ef34bd8ff4e1fb8cc222b78217df917d4833361ea514465e7dae9122a7c7cf7a",
+    "zh:fece9ac372653ab3195630cc9d817ad0f81cce1d2880bec03ffc624591f3702b",
+    "zh:ffd1c3b3e4fa447dd2a78f6696d0dac969cb2996d640e3efbf2a96c49892d298",
+  ]
+}

--- a/terraform/Amplify/main.tf
+++ b/terraform/Amplify/main.tf
@@ -1,0 +1,48 @@
+resource "aws_amplify_app" "main" {
+  name       = "restaking-dashboard"
+  repository = "https://github.com/NethermindEth/restaking-dashboard"
+
+  environment_variables = {
+    "ENV" = "prod"
+  }
+
+  custom_rule {
+    source = "/<*>"
+    status = "404-200"
+    target = "/index.html"
+  }
+    custom_rule {
+    source = "</^[^.]+$|\\.(?!(css|gif|ico|jpg|js|png|txt|svg|woff|woff2|ttf|map|json|webp)$)([^.]+$)/>"
+    status = "200"
+    target = "/index.html"
+  }
+}
+
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.main.id
+  branch_name = "main"
+  stage       = "PRODUCTION"
+
+  enable_auto_build = false
+}
+
+resource "aws_amplify_domain_association" "main" {
+  app_id      = aws_amplify_app.main.id
+  domain_name = "restaking.info"
+
+  wait_for_verification = false
+
+  # https://stage.restaking.info
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = "stage"
+  }
+}
+
+
+resource "aws_amplify_webhook" "stage" {
+  app_id      = aws_amplify_app.main.id
+  branch_name = aws_amplify_branch.main.branch_name
+  description = "stage"
+}
+

--- a/terraform/Amplify/provider.tf
+++ b/terraform/Amplify/provider.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+    bucket = "restaking-dashboard-terraform-state"
+    key    = "frontend.tfstate"
+    region = "us-east-2"
+  }
+
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "Restaking Dashboard"
+    }
+  }
+}


### PR DESCRIPTION
The AWS Amplify app was provisioned manually to deliver the solution quickly. This PR is to ensure all manual configuration will be managed by infrastructure code.