### PR TITLE
Fix AVS list minor design issues

### DIFF
--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -230,7 +230,7 @@ export default function AVSList() {
                       navigate(`/avs/${avs.address}`, { state: { avs } })
                     }
                     key={`avs-item-${i}`}
-                    className="cursor-pointer border-t border-outline hover:bg-default"
+                    className="cursor-pointer border-t border-outline transition-colors hover:bg-default"
                   >
                     <TableCell className="p-5">
                       <div className="flex items-center gap-x-3">

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -113,10 +113,6 @@ export default function AVSList() {
     dispatch({ searchTerm: e.target.value });
   };
 
-  const truncate = str => {
-    return str.length > 42 ? str.substring(0, 42) + '...' : str;
-  };
-
   useEffect(() => {
     const page = searchParams.get('page') ?? 1;
 
@@ -148,43 +144,42 @@ export default function AVSList() {
   }, [dispatch, debouncedSearchTerm]);
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-1">
-        <div className="font-display text-3xl font-medium text-foreground-1">
-          AVS
-        </div>
-        <div className="mb-6 flex w-full flex-col items-start justify-between gap-4 lg:flex-row lg:items-center">
-          <div className="font-display text-base font-medium text-foreground-1">
-            Actively Validated Services
-          </div>
-          <Input
-            classNames={{
-              inputWrapper:
-                'border-outline data-[hover=true]:border-foreground-1',
-              input: 'placeholder:text-subtitle'
-            }}
-            value={state.searchTerm ?? ''}
-            onChange={handleSearch}
-            type="text"
-            color="primary"
-            placeholder="Search by AVS"
-            radius="sm"
-            className="lg:w-96"
-            variant="bordered"
-            endContent={
-              <span className="material-symbols-outlined text-foreground-2">
-                search
-              </span>
-            }
-          />
-        </div>
+    <div className="flex h-full flex-col">
+      <div className="font-display text-3xl font-medium text-foreground-1">
+        AVS
       </div>
-      <div className="rounded-lg border border-outline bg-content1 text-sm">
+      <div className="mb-4 flex w-full flex-col items-start justify-between gap-4 lg:flex-row lg:items-center">
+        <div className="text-foreground-1">Actively Validated Services</div>
+        <Input
+          classNames={{
+            inputWrapper:
+              'border-outline data-[hover=true]:border-foreground-1',
+            input: 'placeholder:text-subtitle'
+          }}
+          value={state.searchTerm ?? ''}
+          onChange={handleSearch}
+          type="text"
+          color="primary"
+          placeholder="Search by AVS"
+          radius="sm"
+          className="lg:w-96"
+          variant="bordered"
+          endContent={
+            <span className="material-symbols-outlined text-foreground-2">
+              search
+            </span>
+          }
+        />
+      </div>
+      <div className="flex flex-1 flex-col rounded-lg border border-outline bg-content1 text-sm">
         <Table
-          aria-label="Actively validated services list"
+          aria-label="AVS list"
           layout="fixed"
           removeWrapper
-          className="overflow-x-auto"
+          classNames={{
+            base: 'overflow-x-auto h-full',
+            table: 'h-full'
+          }}
           sortDescriptor={state.sortDescriptor}
           onSortChange={e => dispatch({ sortDescriptor: e })}
         >
@@ -201,9 +196,9 @@ export default function AVSList() {
           </TableHeader>
           <TableBody
             emptyContent={
-              <div className="flex h-[41.8rem] flex-col items-center justify-center">
+              <div className="flex flex-col items-center justify-center">
                 <span className="text-lg text-foreground-2">
-                  No result found for {truncate(state.searchTerm ?? '')}
+                  No result found for {state.searchTerm?.substring(0, 42)}...
                 </span>
               </div>
             }
@@ -211,17 +206,17 @@ export default function AVSList() {
             {state.isFetchingAvsData
               ? [...Array(10)].map((_, i) => (
                   <TableRow key={i} className="border-t border-outline">
-                    <TableCell className="h-[3.82rem] w-2/5">
-                      <Skeleton className="h-5 rounded-md dark:bg-default" />
+                    <TableCell className="w-2/5 px-5 py-6">
+                      <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
                     <TableCell className="w-1/5">
-                      <Skeleton className="h-5 rounded-md bg-default dark:bg-default" />
+                      <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
                     <TableCell className="w-1/5">
-                      <Skeleton className="h-5 rounded-md bg-default dark:bg-default" />
+                      <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
                     <TableCell className="w-1/5">
-                      <Skeleton className="h-5 rounded-md bg-default dark:bg-default" />
+                      <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
                   </TableRow>
                 ))

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -160,12 +160,13 @@ export default function AVSList() {
           <Input
             classNames={{
               inputWrapper:
-                'border border-outline data-[hover=true]:border-foreground-1',
+                'border-outline data-[hover=true]:border-foreground-1',
               input: 'placeholder:text-subtitle'
             }}
             value={state.searchTerm ?? ''}
             onChange={handleSearch}
             type="text"
+            color="primary"
             placeholder="Search by AVS"
             radius="sm"
             className="lg:w-96"

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -209,13 +209,13 @@ export default function AVSList() {
                     <TableCell className="w-2/5 px-5 py-6">
                       <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5">
+                    <TableCell className="w-1/5 px-5 py-6">
                       <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5">
+                    <TableCell className="w-1/5 px-5 py-6">
                       <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5">
+                    <TableCell className="w-1/5 px-5 py-6">
                       <Skeleton className="h-5 rounded-md bg-default" />
                     </TableCell>
                   </TableRow>
@@ -267,7 +267,7 @@ export default function AVSList() {
               state.avs &&
               [...Array(10 - state.avs.length)].map((_, i) => (
                 <TableRow key={i}>
-                  <TableCell className="h-[3.82rem] w-2/5"></TableCell>
+                  <TableCell className="w-2/5 p-5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -267,7 +267,7 @@ export default function AVSList() {
               state.avs &&
               [...Array(10 - state.avs.length)].map((_, i) => (
                 <TableRow key={i}>
-                  <TableCell className="w-2/5 p-5"></TableCell>
+                  <TableCell className="h-full w-2/5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>
                   <TableCell className="w-1/5"></TableCell>

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -1,5 +1,6 @@
 import { formatETH, formatNumber, formatUSD } from '../shared/formatters';
 import {
+  Image,
   Input,
   Skeleton,
   Table,
@@ -226,28 +227,28 @@ export default function AVSList() {
               : state.avs?.map((avs, i) => (
                   <TableRow
                     onClick={() =>
-                      navigate(`/avs/${avs.address}`, { state: { avs: avs } })
+                      navigate(`/avs/${avs.address}`, { state: { avs } })
                     }
                     key={`avs-item-${i}`}
                     className="cursor-pointer border-t border-outline hover:bg-default"
                   >
                     <TableCell className="p-5">
-                      <div className="flex gap-x-3">
-                        <span className="size-3">
+                      <div className="flex items-center gap-x-3">
+                        <span className="min-w-5">
                           {(searchParams.get('page') - 1) * 10 + i + 1}
                         </span>
                         {avs.metadata?.logo ? (
-                          <img
-                            className="size-5 rounded-full bg-foreground-2"
+                          <Image
+                            className="size-8 min-w-8 rounded-full border-2 border-foreground-2 bg-foreground-2"
                             src={avs.metadata?.logo}
                           />
                         ) : (
-                          <span className="material-symbols-outlined flex h-5 min-w-5 items-center justify-center rounded-full text-lg text-yellow-300">
-                            warning
+                          <span className="material-symbols-outlined flex size-8 min-w-8 items-center justify-center rounded-full bg-foreground-2">
+                            question_mark
                           </span>
                         )}
                         <span className="truncate">
-                          {avs.metadata?.name ?? 'N/A'}
+                          {avs.metadata?.name || avs.address}
                         </span>
                       </div>
                     </TableCell>
@@ -257,7 +258,7 @@ export default function AVSList() {
                     <TableCell className="pr-8 text-end">
                       {formatNumber(avs.operators)}
                     </TableCell>
-                    <TableCell className="flex flex-col items-end justify-center pr-8">
+                    <TableCell className="pr-8 text-end">
                       <div>{formatUSD(avs.strategiesTotal * state.rate)}</div>
                       <div className="text-xs text-subtitle">
                         {formatETH(avs.strategiesTotal)}

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -198,7 +198,11 @@ export default function AVSList() {
             emptyContent={
               <div className="flex flex-col items-center justify-center">
                 <span className="text-lg text-foreground-2">
-                  No result found for {state.searchTerm?.substring(0, 42)}...
+                  No result found for &quot;
+                  {state.searchTerm?.length > 42
+                    ? `${state.searchTerm?.substring(0, 42)}...`
+                    : state.searchTerm}
+                  &quot;
                 </span>
               </div>
             }

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -252,13 +252,13 @@ export default function AVSList() {
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell className="pr-8 text-end">
+                    <TableCell className="pe-8 text-end">
                       {formatNumber(avs.stakers)}
                     </TableCell>
-                    <TableCell className="pr-8 text-end">
+                    <TableCell className="pe-8 text-end">
                       {formatNumber(avs.operators)}
                     </TableCell>
-                    <TableCell className="pr-8 text-end">
+                    <TableCell className="pe-8 text-end">
                       <div>{formatUSD(avs.strategiesTotal * state.rate)}</div>
                       <div className="text-xs text-subtitle">
                         {formatETH(avs.strategiesTotal)}

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -22,7 +22,7 @@ const columns = [
   {
     key: 'avs',
     label: 'AVS',
-    className: 'w-64 md:w-2/5'
+    className: 'w-64 md:w-2/5 ps-12'
   },
   {
     key: 'staker',

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -210,17 +210,17 @@ export default function AVSList() {
             {state.isFetchingAvsData
               ? [...Array(10)].map((_, i) => (
                   <TableRow key={i} className="border-t border-outline">
-                    <TableCell className="w-2/5 px-5 py-6">
-                      <Skeleton className="h-5 rounded-md bg-default" />
+                    <TableCell className="w-2/5 py-6 pe-8 ps-4">
+                      <Skeleton className="h-4 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5 px-5 py-6">
-                      <Skeleton className="h-5 rounded-md bg-default" />
+                    <TableCell className="w-1/5 py-6 pe-8 ps-4">
+                      <Skeleton className="h-4 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5 px-5 py-6">
-                      <Skeleton className="h-5 rounded-md bg-default" />
+                    <TableCell className="w-1/5 py-6 pe-8 ps-4">
+                      <Skeleton className="h-4 rounded-md bg-default" />
                     </TableCell>
-                    <TableCell className="w-1/5 px-5 py-6">
-                      <Skeleton className="h-5 rounded-md bg-default" />
+                    <TableCell className="w-1/5 py-6 pe-8 ps-4">
+                      <Skeleton className="h-4 rounded-md bg-default" />
                     </TableCell>
                   </TableRow>
                 ))

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -228,7 +228,7 @@ export default function AVSList() {
                     key={`avs-item-${i}`}
                     className="cursor-pointer border-t border-outline transition-colors hover:bg-default"
                   >
-                    <TableCell className="p-5">
+                    <TableCell className="p-4">
                       <div className="flex items-center gap-x-3">
                         <span className="min-w-5">
                           {(searchParams.get('page') - 1) * 10 + i + 1}


### PR DESCRIPTION
Fixed some design issues on the AVS list view:

- Added border to AVS logos so they stand out more, and resized them according to the design
- Fixed some alignment issues
- For AVS with no metadata, display the address instead of the name and a question mark instead of a logo
- Revised and optimized page layout
- Removed hardcoded heights

Before
![Screenshot 2024-07-22 191740](https://github.com/user-attachments/assets/38a47661-e6b9-487f-9b9a-b0b88cca8df4)
![Screenshot 2024-07-22 192453](https://github.com/user-attachments/assets/76c4c65e-cb95-4619-9d23-31476babae4c)

After
![Screenshot 2024-07-22 191721](https://github.com/user-attachments/assets/687df1b3-5ba9-4ae4-8362-e2f905790f28)
![Screenshot 2024-07-22 192352](https://github.com/user-attachments/assets/ceba9a51-1fe7-49a6-8823-4518962a83ca)
