### PR TITLE
Implement AVS list error handling

### DIFF
--- a/src/@services/AVSService.js
+++ b/src/@services/AVSService.js
@@ -1,14 +1,11 @@
 import { apiGet } from './apiCall';
+import BaseService from './BaseService';
 
-export default class AVSService {
+export default class AVSService extends BaseService {
   async getAll(pageNumber, search, sort, signal) {
     const pageIndex = Math.max(0, pageNumber - 1);
-    const response = await apiGet('/avs', {
-      query: {
-        'page-index': pageIndex,
-        search,
-        sort
-      },
+    const response = await BaseService._get('/avs', {
+      query: { 'page-index': pageIndex, search, sort },
       signal
     });
 
@@ -16,8 +13,7 @@ export default class AVSService {
       return await response.json();
     }
 
-    // TODO: Handle error
-    return await response.json();
+    throw await this._createError(response);
   }
 
   async getAVSDetails(address) {

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -49,7 +49,7 @@ export default function AVSList() {
   const abortController = useRef(null);
   const [state, dispatch] = useMutativeReducer(reduceState, {
     avs: [],
-    isFetchingAvsData: false,
+    isFetchingData: false,
     searchTerm: searchParams.get('search'),
     error: null,
     rate: 1,
@@ -69,7 +69,7 @@ export default function AVSList() {
   const fetchAVS = useCallback(
     async (pageNumber, search, sort) => {
       try {
-        dispatch({ isFetchingAvsData: true, error: null });
+        dispatch({ isFetchingData: true, error: null });
 
         if (abortController.current) {
           abortController.current.abort();
@@ -85,7 +85,7 @@ export default function AVSList() {
 
         dispatch({
           avs: response.results,
-          isFetchingAvsData: false,
+          isFetchingData: false,
           rate: response.rate,
           totalPages: Math.ceil(response.totalCount / 10)
         });
@@ -95,7 +95,7 @@ export default function AVSList() {
         if (e.name !== 'AbortError') {
           dispatch({
             error: handleServiceError(e),
-            isFetchingAvsData: false
+            isFetchingData: false
           });
         }
       }
@@ -173,13 +173,25 @@ export default function AVSList() {
         />
       </div>
 
-      {!state.isFetchingAvsData && state.error && (
+      {!state.isFetchingData && state.error && (
         <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-outline bg-content1 text-sm">
           <ErrorMessage error={state.error} />
         </div>
       )}
 
-      {!state.error && (
+      {!state.isFetchingData && state.avs.length === 0 && (
+        <div className="flex flex-1 items-center justify-center rounded-lg border border-outline bg-content1 text-sm">
+          <span className="text-lg text-foreground-2">
+            No AVS found for &quot;
+            {debouncedSearchTerm?.length > 42
+              ? `${debouncedSearchTerm?.substring(0, 42)}...`
+              : debouncedSearchTerm}
+            &quot;
+          </span>
+        </div>
+      )}
+
+      {!state.error && state.avs.length > 0 && (
         <div className="flex flex-1 flex-col rounded-lg border border-outline bg-content1 text-sm">
           <Table
             aria-label="AVS list"
@@ -205,7 +217,7 @@ export default function AVSList() {
               )}
             </TableHeader>
             <TableBody>
-              {state.isFetchingAvsData
+              {state.isFetchingData
                 ? [...Array(10)].map((_, i) => (
                     <TableRow key={i} className="border-t border-outline">
                       <TableCell className="w-2/5 py-6 pe-8 ps-4">
@@ -265,7 +277,7 @@ export default function AVSList() {
                     </TableRow>
                   ))}
 
-              {!state.isFetchingAvsData &&
+              {!state.isFetchingData &&
                 state.avs &&
                 [...Array(10 - state.avs.length)].map((_, i) => (
                   <TableRow key={i}>

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -60,7 +60,7 @@ export default function AVSList() {
             ? 'descending'
             : 'ascending'
         }
-      : null
+      : { column: 'tvl', direction: 'descending' }
   });
 
   const debouncedSearchTerm = useDebouncedSearch(state.searchTerm ?? '', 300);
@@ -187,7 +187,7 @@ export default function AVSList() {
             {column => (
               <TableColumn
                 allowsSorting
-                className={`bg-transparent py-4 text-sm font-normal leading-5 text-foreground-active data-[hover=true]:text-foreground-2 ${column.className}`}
+                className={`text-foreground-active bg-transparent py-4 text-sm font-normal leading-5 data-[hover=true]:text-foreground-2 ${column.className}`}
                 key={column.key}
               >
                 {column.label}

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -187,7 +187,8 @@ export default function AVSList() {
             removeWrapper
             classNames={{
               base: 'overflow-x-auto h-full',
-              table: 'h-full'
+              table: 'h-full',
+              thead: '[&>tr:last-child]:hidden'
             }}
             sortDescriptor={state.sortDescriptor}
             onSortChange={e => dispatch({ sortDescriptor: e })}

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -179,22 +179,11 @@ export default function AVSList() {
         </div>
       )}
 
-      {!state.isFetchingData && state.avs.length === 0 && (
-        <div className="flex flex-1 items-center justify-center rounded-lg border border-outline bg-content1 text-sm">
-          <span className="text-lg text-foreground-2">
-            No AVS found for &quot;
-            {debouncedSearchTerm?.length > 42
-              ? `${debouncedSearchTerm?.substring(0, 42)}...`
-              : debouncedSearchTerm}
-            &quot;
-          </span>
-        </div>
-      )}
-
-      {!state.error && state.avs.length > 0 && (
+      {!state.error && (
         <div className="flex flex-1 flex-col rounded-lg border border-outline bg-content1 text-sm">
           <Table
             aria-label="AVS list"
+            hideHeader={!state.isFetchingData && state.avs.length == 0}
             layout="fixed"
             removeWrapper
             classNames={{
@@ -216,7 +205,19 @@ export default function AVSList() {
                 </TableColumn>
               )}
             </TableHeader>
-            <TableBody>
+            <TableBody
+              emptyContent={
+                <div className="flex flex-col items-center justify-center">
+                  <span className="text-lg text-foreground-2">
+                    No AVS found for &quot;
+                    {debouncedSearchTerm.length > 42
+                      ? `${debouncedSearchTerm.substring(0, 42)}...`
+                      : debouncedSearchTerm}
+                    &quot;
+                  </span>
+                </div>
+              }
+            >
               {state.isFetchingData
                 ? [...Array(10)].map((_, i) => (
                     <TableRow key={i} className="border-t border-outline">
@@ -278,7 +279,7 @@ export default function AVSList() {
                   ))}
 
               {!state.isFetchingData &&
-                state.avs &&
+                state.avs?.length > 0 &&
                 [...Array(10 - state.avs.length)].map((_, i) => (
                   <TableRow key={i}>
                     <TableCell className="h-full w-2/5"></TableCell>

--- a/src/avs/AVSList.jsx
+++ b/src/avs/AVSList.jsx
@@ -175,19 +175,7 @@ export default function AVSList() {
 
       {!state.isFetchingAvsData && state.error && (
         <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-outline bg-content1 text-sm">
-          {state.error.message === 'No AVS found' ? (
-            <div className="flex flex-col items-center justify-center">
-              <span className="text-lg text-foreground-2">
-                No result found for &quot;
-                {state.searchTerm?.length > 42
-                  ? `${state.searchTerm?.substring(0, 42)}...`
-                  : state.searchTerm}
-                &quot;
-              </span>
-            </div>
-          ) : (
-            <ErrorMessage error={state.error} />
-          )}
+          <ErrorMessage error={state.error} />
         </div>
       )}
 


### PR DESCRIPTION
- Added default sorting indication
- Added error handling
- Modified table empty state

This is how the errors will look:

<img width="1512" alt="Screenshot 2024-07-23 at 8 26 33 PM" src="https://github.com/user-attachments/assets/3f6e8ffa-2097-4ae4-965f-5f7d0219429a">

When there is no AVS found for a search query the table headers will not be shown

<img width="1512" alt="Screenshot 2024-07-23 at 8 28 42 PM" src="https://github.com/user-attachments/assets/b6d5eef9-2eaa-4fa5-ba1b-f78e17260698">
