### PR TITLE
Unify AVS and operator views

### DIFF
--- a/src/avs/AVSDetailsHeader.jsx
+++ b/src/avs/AVSDetailsHeader.jsx
@@ -1,50 +1,25 @@
-import { Button, Link } from '@nextui-org/react';
-import { reduceState, truncateAddress } from '../shared/helpers';
+import CopyButton from '../shared/CopyButton';
+import { Link } from '@nextui-org/react';
 import ThirdPartyLogo from '../shared/ThirdPartyLogo';
-import { useCallback } from 'react';
-import { useMutativeReducer } from 'use-mutative';
+import { truncateAddress } from '../shared/helpers';
 
 export default function AVSDetailsHeader({ avs }) {
-  const [state, dispatch] = useMutativeReducer(reduceState, {
-    isCopied: false,
-    copyTimeout: null
-  });
-
-  const handleCopy = useCallback(
-    value => {
-      if ('clipboard' in navigator) {
-        navigator.clipboard.writeText(value).catch();
-
-        if (state.copyTimeout) {
-          clearTimeout(state.copyTimeout);
-        }
-
-        dispatch({
-          isCopied: true,
-          copyTimeout: setTimeout(() => dispatch({ isCopied: false }), 2000)
-        });
-      }
-    },
-    [dispatch, state.copyTimeout]
-  );
-
   return (
-    <div className="w-full break-words rounded-lg border border-outline bg-content1 p-4">
-      <div className="flex items-center">
+    <div className="flex w-full flex-row flex-wrap items-center gap-x-5 gap-y-2 break-words rounded-lg border border-outline bg-content1 p-4">
+      <div className="flex basis-full items-center gap-4">
         <ThirdPartyLogo className="size-12 min-w-12" url={avs.metadata?.logo} />
-        <div className="ml-2 font-display text-3xl font-medium text-foreground-1">
+        <span className="font-display text-3xl font-medium text-foreground-1">
           <span>{avs.metadata?.name ?? truncateAddress(avs.address)}</span>
-
           {/*TODO: implement ranking when coming from list view & accessing directly avs*/}
           {/* <span className="ml-2 inline-block translate-y-[-25%] rounded-md bg-foreground-2 p-1 text-xs text-content1"> */}
           {/*   # 1 */}
           {/* </span> */}
-        </div>
+        </span>
       </div>
-      <div className="my-4 break-words text-xs text-foreground-1">
+      <span className="basis-full break-words pt-4 text-xs text-foreground-1">
         {avs.metadata?.description}
-      </div>
-      <div className="flex items-center gap-1">
+      </span>
+      <div className="flex basis-full items-center gap-1 lg:basis-0">
         <Link
           className="truncate text-xs text-secondary"
           href={`https://etherscan.io/address/${avs.address}`}
@@ -53,55 +28,43 @@ export default function AVSDetailsHeader({ avs }) {
         >
           {avs.address}
         </Link>
-        <Button
-          className="border-none text-secondary"
-          isIconOnly
-          onClick={() => handleCopy(avs.address)}
+        <CopyButton color="secondary" value={avs.address} />
+      </div>
+      {avs.metadata?.website && (
+        <Link
+          className="flex items-center text-secondary"
+          href={avs.metadata.website}
+          rel="noreferrer"
           size="sm"
-          variant="ghost"
+          target="_blank"
         >
-          <span className="material-symbols-outlined text-xl text-secondary">
-            {state.isCopied ? 'check' : 'content_copy'}
+          <span className="material-symbols-outlined me-1 text-xl text-secondary">
+            language
           </span>
-        </Button>
-      </div>
-      <div className="flex gap-4">
-        {avs.metadata?.website && (
-          <Link
-            className="flex items-center text-secondary"
-            href={avs.metadata.website}
-            rel="noreferrer"
-            size="sm"
-            target="_blank"
-          >
-            <span className="material-symbols-outlined me-1 text-xl text-secondary">
-              language
-            </span>
-            Website
-          </Link>
-        )}
-        {avs.metadata?.twitter && (
-          <Link
-            className="border-none text-secondary"
-            href={avs.metadata.twitter}
-            rel="noreferrer"
-            size="sm"
-            target="_blank"
-          >
-            <span
-              className="me-1 h-4 w-4 bg-secondary"
-              style={{
-                mask: 'url(/assets/x.svg) no-repeat',
-                backgroundColor: 'hsl(var(--app-secondary))'
-              }}
-            ></span>
-            @
-            {avs.metadata.twitter.substring(
-              avs.metadata.twitter.lastIndexOf('/') + 1
-            )}
-          </Link>
-        )}
-      </div>
+          Website
+        </Link>
+      )}
+      {avs.metadata?.twitter && (
+        <Link
+          className="border-none text-secondary"
+          href={avs.metadata.twitter}
+          rel="noreferrer"
+          size="sm"
+          target="_blank"
+        >
+          <span
+            className="me-1 h-4 w-4 bg-secondary"
+            style={{
+              mask: 'url(/assets/x.svg) no-repeat',
+              backgroundColor: 'hsl(var(--app-secondary))'
+            }}
+          ></span>
+          @
+          {avs.metadata.twitter.substring(
+            avs.metadata.twitter.lastIndexOf('/') + 1
+          )}
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/avs/AVSDetailsTVLTab.jsx
+++ b/src/avs/AVSDetailsTVLTab.jsx
@@ -26,6 +26,7 @@ import { useMutativeReducer } from 'use-mutative';
 import { useParams } from 'react-router-dom';
 import { useServices } from '../@services/ServiceContext';
 import { useTailwindBreakpoint } from '../shared/useTailwindBreakpoint';
+import ThirdPartyLogo from '../shared/ThirdPartyLogo';
 
 export default function AVSDetailsTVLTab({
   totalTokens,
@@ -197,7 +198,10 @@ function TokensBreakdownList({ totalTokens, isAVSLoading, ethRate }) {
             <TableRow key={key}>
               <TableCell className="pl-0 text-sm">
                 <div className="flex items-center gap-x-2 truncate">
-                  <Image height={16} src={tokens[key].logo} width={16} />
+                  <ThirdPartyLogo
+                    className="size-5 min-w-5"
+                    url={tokens[key].logo}
+                  />
                   <span className="truncate text-foreground-2">
                     {tokens[key].name}
                   </span>{' '}
@@ -280,15 +284,9 @@ function LSTBreakdownList({ lst, ethRate, isAVSLoading }) {
             <TableRow key={key}>
               <TableCell className="pl-0 text-sm">
                 <div className="flex items-center gap-x-2">
-                  <Image
-                    classNames={{
-                      // override tailwind's base img styling that doesn't respect specified dimensions
-                      img: 'h-4 w-4 max-w-none object-contain'
-                    }}
-                    fallbackSrc="/eth.png"
-                    height={16}
-                    src={lstStrategyAssetMapping[key].logo}
-                    width={16}
+                  <ThirdPartyLogo
+                    className="size-5 min-w-5"
+                    url={lstStrategyAssetMapping[key].logo}
                   />
                   <span className="truncate text-foreground-2">
                     {lstStrategyAssetMapping[key]?.name}

--- a/src/avs/charts/OperatorsTabLineChart.jsx
+++ b/src/avs/charts/OperatorsTabLineChart.jsx
@@ -128,12 +128,12 @@ export default function OperatorsTabLineChart({ points, height, width }) {
   );
 
   return (
-    <div className="rounded-lg border border-outline bg-content1">
-      <div className="mb-6 flex justify-between p-4">
-        <div className="hidden flex-1 sm:block">
-          <div className="font-display text-xl text-foreground-1">
+    <div className="rounded-lg border border-outline bg-content1 p-4">
+      <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
+        <div className="flex-1">
+          <span className="font-display text-xl text-foreground-1">
             Operators over time
-          </div>
+          </span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span
@@ -144,11 +144,10 @@ export default function OperatorsTabLineChart({ points, height, width }) {
             </span>
           </div>
         </div>
-
-        <div className="flex w-full flex-1 flex-col justify-between gap-x-2 gap-y-2 sm:flex-row sm:justify-end">
+        <div className="flex flex-1 justify-end">
           <Tabs
             classNames={tabs}
-            defaultSelectedKey="all"
+            defaultSelectedKey="3m"
             disabledKeys={disabledKeys}
             onSelectionChange={handleTimelineSelectionChange}
             size="sm"
@@ -161,7 +160,6 @@ export default function OperatorsTabLineChart({ points, height, width }) {
           </Tabs>
         </div>
       </div>
-
       <svg
         className="w-full touch-pan-y"
         height={height}
@@ -205,7 +203,7 @@ export default function OperatorsTabLineChart({ points, height, width }) {
             top={state.maxY}
           />
           <LinePath
-            className="stroke-chart-9"
+            className="stroke-chart-9 stroke-2"
             curve={curveMonotoneX}
             data={state.filteredPoints}
             x={d => scaleDate(getDate(d)) ?? 0}
@@ -214,7 +212,7 @@ export default function OperatorsTabLineChart({ points, height, width }) {
 
           {tooltipOpen && (
             <Circle
-              className="fill-chart-9 cursor-pointer stroke-2 dark:stroke-white"
+              className="cursor-pointer fill-chart-9 stroke-2 dark:stroke-white"
               cx={tooltipLeft}
               cy={tooltipTop}
               r={4}
@@ -255,7 +253,7 @@ export default function OperatorsTabLineChart({ points, height, width }) {
   );
 }
 
-const margin = { top: 20, right: 40, bottom: 40, left: 20 };
+const margin = { top: 20, right: 40, bottom: 24, left: 0 };
 const timelines = {
   '1w': 7,
   '1m': 30,

--- a/src/avs/charts/TVLTabLineChart.jsx
+++ b/src/avs/charts/TVLTabLineChart.jsx
@@ -143,12 +143,12 @@ export default function TVLTabLineChart({ points, height, width }) {
   );
 
   return (
-    <div className="rounded-lg border border-outline bg-content1">
-      <div className="mb-6 flex justify-between p-4">
-        <div className="hidden flex-1 sm:block">
-          <div className="font-display text-xl text-foreground-1">
+    <div className="rounded-lg border border-outline bg-content1 p-4">
+      <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
+        <div className="flex-1">
+          <span className="font-display text-xl text-foreground-1">
             TVL over time
-          </div>
+          </span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span
@@ -159,31 +159,28 @@ export default function TVLTabLineChart({ points, height, width }) {
             </span>
           </div>
         </div>
-
-        <div className="flex w-full flex-1 flex-col justify-between gap-x-2 gap-y-2 sm:flex-row sm:justify-end">
-          <Tabs
-            classNames={tabs}
-            defaultSelectedKey="usd"
-            onSelectionChange={handleRateSelectionChange}
-            size="sm"
-          >
-            <Tab key="usd" title="USD" />
-            <Tab key="eth" title="ETH" />
-          </Tabs>
-          <Tabs
-            classNames={tabs}
-            defaultSelectedKey="all"
-            disabledKeys={disabledKeys}
-            onSelectionChange={handleTimelineSelectionChange}
-            size="sm"
-          >
-            <Tab key="1w" title="1W" />
-            <Tab key="1m" title="1M" />
-            <Tab key="3m" title="3M" />
-            <Tab key="1y" title="1Y" />
-            <Tab key="all" title="All" />
-          </Tabs>
-        </div>
+        <Tabs
+          classNames={tabs}
+          defaultSelectedKey="usd"
+          onSelectionChange={handleRateSelectionChange}
+          size="sm"
+        >
+          <Tab key="usd" title="USD" />
+          <Tab key="eth" title="ETH" />
+        </Tabs>
+        <Tabs
+          classNames={tabs}
+          defaultSelectedKey="3m"
+          disabledKeys={disabledKeys}
+          onSelectionChange={handleTimelineSelectionChange}
+          size="sm"
+        >
+          <Tab key="1w" title="1W" />
+          <Tab key="1m" title="1M" />
+          <Tab key="3m" title="3M" />
+          <Tab key="1y" title="1Y" />
+          <Tab key="all" title="All" />
+        </Tabs>
       </div>
 
       <svg
@@ -229,7 +226,7 @@ export default function TVLTabLineChart({ points, height, width }) {
             top={state.maxY}
           />
           <LinePath
-            className="stroke-chart-9"
+            className="stroke-chart-9 stroke-2"
             curve={curveMonotoneX}
             data={state.filteredPoints}
             x={d => scaleDate(getDate(d)) ?? 0}
@@ -281,7 +278,7 @@ export default function TVLTabLineChart({ points, height, width }) {
   );
 }
 
-const margin = { top: 20, right: 40, bottom: 40, left: 20 };
+const margin = { top: 20, right: 40, bottom: 24, left: 0 };
 const timelines = {
   '1w': 7,
   '1m': 30,

--- a/src/operators/OperatorDetails.jsx
+++ b/src/operators/OperatorDetails.jsx
@@ -83,7 +83,7 @@ export default function OperatorDetails() {
 
       {!state.isOperatorLoading && !state.error && (
         <>
-          <div className="mb-4 flex w-full flex-row flex-wrap items-center gap-2 break-words rounded-lg border border-outline bg-content1 p-4">
+          <div className="mb-4 flex w-full flex-row flex-wrap items-center gap-x-5 gap-y-2 break-words rounded-lg border border-outline bg-content1 p-4">
             <div className="flex basis-full items-center gap-4">
               <ThirdPartyLogo
                 className="size-12 min-w-12"
@@ -101,7 +101,7 @@ export default function OperatorDetails() {
             <span className="basis-full break-words pt-4 text-xs text-foreground-1">
               {state.operator.metadata?.description}
             </span>
-            <div className="flex basis-full items-center gap-1 lg:me-4 lg:basis-0">
+            <div className="flex basis-full items-center gap-1 lg:basis-0">
               <Link
                 className="truncate text-xs text-secondary"
                 href={`https://etherscan.io/address/${state.operator.address}`}


### PR DESCRIPTION
Refactored and unified AVS and operator views:

- Unified headers
- Unified 3rd party logo stylings
- Unified chart title handling based on screen sizes
- Made "3M" the default chart period tab
- Minor refactoring

Of course, there are many other things to refactor, but we'll do that later.