### PR TITLE
Revise chart title fonts and scaling

### DIFF
--- a/src/avs/AVSDetails.jsx
+++ b/src/avs/AVSDetails.jsx
@@ -98,7 +98,7 @@ export default function AVSDetails() {
           href={`/avs/${address}/tvl`}
           key={`/avs/${address}/tvl`}
           title={
-            <div className="flex flex-col">
+            <div className="flex flex-col items-center">
               <div className="text-sm text-foreground-2 group-aria-selected:text-foreground-1">
                 Total value
               </div>
@@ -129,7 +129,7 @@ export default function AVSDetails() {
           href={`/avs/${address}/operators`}
           key={`/avs/${address}/operators`}
           title={
-            <div className="flex flex-col">
+            <div className="flex flex-col items-center">
               <div className="text-sm text-foreground-2 group-aria-selected:text-foreground-1">
                 Operators
               </div>
@@ -154,7 +154,7 @@ export default function AVSDetails() {
         <Tab
           key="restakers"
           title={
-            <div className="flex flex-col">
+            <div className="flex flex-col items-center">
               <div className="text-sm">Restakers</div>
               <div>
                 {state.isAVSLoading ? (

--- a/src/avs/charts/OperatorsTabLineChart.jsx
+++ b/src/avs/charts/OperatorsTabLineChart.jsx
@@ -69,7 +69,7 @@ export default function OperatorsTabLineChart({ points, height, width }) {
     return scaleLinear({
       domain: [
         Math.min(...state.filteredPoints.map(getValue)),
-        Math.max(...state.filteredPoints.map(getValue))
+        Math.max(...state.filteredPoints.map(getValue)) * 1.1
       ],
       range: [state.maxY, 0]
     });
@@ -131,9 +131,7 @@ export default function OperatorsTabLineChart({ points, height, width }) {
     <div className="rounded-lg border border-outline bg-content1 p-4">
       <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
         <div className="flex-1">
-          <span className="font-display text-xl text-foreground-1">
-            Operators over time
-          </span>
+          <span className="text-foreground-1">Operators over time</span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span

--- a/src/avs/charts/TVLTabLineChart.jsx
+++ b/src/avs/charts/TVLTabLineChart.jsx
@@ -73,7 +73,7 @@ export default function TVLTabLineChart({ points, height, width }) {
     return scaleLinear({
       domain: [
         Math.min(...state.filteredPoints.map(getValue)),
-        Math.max(...state.filteredPoints.map(getValue))
+        Math.max(...state.filteredPoints.map(getValue)) * 1.1
       ],
       range: [state.maxY, 0]
     });
@@ -146,9 +146,7 @@ export default function TVLTabLineChart({ points, height, width }) {
     <div className="rounded-lg border border-outline bg-content1 p-4">
       <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
         <div className="flex-1">
-          <span className="font-display text-xl text-foreground-1">
-            TVL over time
-          </span>
+          <span className="text-foreground-1">TVL over time</span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span

--- a/src/operators/charts/OperatorRestakersLineChart.jsx
+++ b/src/operators/charts/OperatorRestakersLineChart.jsx
@@ -138,7 +138,7 @@ function LineChart({ points, height, width }) {
     return scaleLinear({
       domain: [
         Math.min(...state.filteredPoints.map(getValue)),
-        Math.max(...state.filteredPoints.map(getValue))
+        Math.max(...state.filteredPoints.map(getValue)) * 1.1
       ],
       range: [state.maxY, 0]
     });
@@ -200,9 +200,7 @@ function LineChart({ points, height, width }) {
     <div className="rounded-lg border border-outline bg-content1 p-4">
       <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
         <div className="flex-1">
-          <span className="font-display text-xl text-foreground-1">
-            Restakers over time
-          </span>
+          <span className="text-foreground-1">Restakers over time</span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span

--- a/src/operators/charts/OperatorTVLLineChart.jsx
+++ b/src/operators/charts/OperatorTVLLineChart.jsx
@@ -144,7 +144,7 @@ function LineChart({ points, height, width }) {
     return scaleLinear({
       domain: [
         Math.min(...state.filteredPoints.map(getValue)),
-        Math.max(...state.filteredPoints.map(getValue))
+        Math.max(...state.filteredPoints.map(getValue)) * 1.1
       ],
       range: [state.maxY, 0]
     });
@@ -217,9 +217,7 @@ function LineChart({ points, height, width }) {
     <div className="rounded-lg border border-outline bg-content1 p-4">
       <div className="mb-6 flex flex-wrap justify-end gap-x-2 gap-y-4 sm:justify-between">
         <div className="flex-1">
-          <span className="font-display text-xl text-foreground-1">
-            TVL over time
-          </span>
+          <span className="text-foreground-1">TVL over time</span>
           <div className="flex gap-x-2 text-sm text-foreground-2">
             <span>{getLatestTotals}</span>
             <span


### PR DESCRIPTION
Changed the chart title fonts to regular and revised scaling to be 110% to give more room.