### PR TITLE
Revise logo focus outline

### DIFF
--- a/src/shared/ResatkingLogo.jsx
+++ b/src/shared/ResatkingLogo.jsx
@@ -1,7 +1,7 @@
 export default function RestakingLogo() {
   return (
     <a
-      className="font-display uppercase tracking-widest text-foreground-1"
+      className="font-display uppercase tracking-widest text-foreground-1 focus:outline focus:outline-2 focus:outline-focus"
       href="/"
     >
       <span className="font-bold">Restaking</span>.info


### PR DESCRIPTION
Revised the logo focus outline to be the same style as other controls.

For the future, we need to ensure the website is keyboard-friendly. Currently, it's partially the case.