### PR TITLE
Ensure navigation is keyboard-friendly 

### DIFF
--- a/src/shared/Sidebar.jsx
+++ b/src/shared/Sidebar.jsx
@@ -1,6 +1,6 @@
+import { Kbd, Link } from '@nextui-org/react';
 import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Link } from '@nextui-org/react';
 import RestakingLogo from './ResatkingLogo';
 
 export default function Sidebar({ onOpenChange }) {
@@ -39,6 +39,16 @@ export default function Sidebar({ onOpenChange }) {
       <header className="flex-none border-l-4 border-transparent px-5 pb-8 pt-6">
         <RestakingLogo />
       </header>
+      <div className="mb-1 hidden justify-end gap-1 pr-1 lg:flex">
+        <Kbd
+          className="rounded-none bg-default/40 text-foreground-1/60"
+          keys={['space']}
+        ></Kbd>
+        <Kbd
+          className="rounded-none bg-default/40 text-foreground-1/60"
+          keys={['enter']}
+        ></Kbd>
+      </div>
       <nav className="flex-none">
         {navItems.map((item, i) => {
           const selected = new RegExp(`(^|/)${item.href}(/|$)`).test(

--- a/src/shared/Sidebar.jsx
+++ b/src/shared/Sidebar.jsx
@@ -9,30 +9,45 @@ export default function Sidebar({ onOpenChange }) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const linkRefs = useRef([]);
 
+  /**
+   * Handles keydown events for the sidebar navigation.
+   *
+   * @param {Event} event - The keydown event object.
+   * @param {number} index - The index of the navigation item.
+   * @return {void}
+   */
   const handleKeyDown = (event, index) => {
     switch (event.key) {
       case ' ':
         event.preventDefault();
         setFocusedIndex(prevIndex =>
-          prevIndex >= navItems.length - 1 ? 0 : prevIndex + 1
+          prevIndex === navItems.length - 1 ? 0 : prevIndex + 1
         );
         break;
       case 'Enter':
+        event.preventDefault();
         navigate(navItems[index].href);
-        if (onOpenChange) {
-          onOpenChange(false);
-        }
+        onOpenChange && onOpenChange(false);
         break;
       default:
         break;
     }
   };
 
+  // setting focus to the focused link
   useEffect(() => {
     if (linkRefs.current[focusedIndex]) {
       linkRefs.current[focusedIndex].focus();
     }
   }, [focusedIndex]);
+
+  // setting focused index to be the current location
+  useEffect(() => {
+    const currentIndex = navItems.findIndex(item =>
+      new RegExp(`(^|/)${item.href}(/|$)`).test(location.pathname)
+    );
+    setFocusedIndex(currentIndex !== -1 ? currentIndex : 0);
+  }, [location.pathname]);
 
   return (
     <div onKeyDown={handleKeyDown} tabIndex={0}>

--- a/src/shared/Sidebar.jsx
+++ b/src/shared/Sidebar.jsx
@@ -1,12 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Link } from '@nextui-org/react';
 import RestakingLogo from './ResatkingLogo';
-import { useLocation } from 'react-router-dom';
 
 export default function Sidebar({ onOpenChange }) {
   const location = useLocation();
+  const navigate = useNavigate();
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const linkRefs = useRef([]);
+
+  const handleKeyDown = (event, index) => {
+    switch (event.key) {
+      case ' ':
+        event.preventDefault();
+        setFocusedIndex(prevIndex =>
+          prevIndex >= navItems.length - 1 ? 0 : prevIndex + 1
+        );
+        break;
+      case 'Enter':
+        navigate(navItems[index].href);
+        if (onOpenChange) {
+          onOpenChange(false);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    if (linkRefs.current[focusedIndex]) {
+      linkRefs.current[focusedIndex].focus();
+    }
+  }, [focusedIndex]);
 
   return (
-    <div>
+    <div onKeyDown={handleKeyDown} tabIndex={0}>
       <header className="flex-none border-l-4 border-transparent px-5 pb-8 pt-6">
         <RestakingLogo />
       </header>
@@ -19,14 +48,18 @@ export default function Sidebar({ onOpenChange }) {
             : 'border-transparent';
           return (
             <Link
-              className={`flex gap-x-2 border-l-4 px-5 py-5 text-foreground-2 transition-all hover:border-foreground-2 hover:bg-default/50 hover:text-foreground-1 hover:opacity-100 data-[focus-visible=true]:outline-offset-[-2px] ${selected}`}
+              className={`flex gap-x-2 border-l-4 px-5 py-5 text-foreground-2 transition-all hover:border-foreground-2 hover:bg-default/50 hover:text-foreground-1 hover:opacity-100 focus:border-foreground-1 focus:bg-default focus:text-foreground-1 focus:outline-none focus:ring-0 ${selected}`}
               href={item.href}
               key={`nav-item-${i}`}
               onPress={() => {
+                navigate(item.href);
                 if (onOpenChange) {
                   onOpenChange(false);
                 }
               }}
+              ref={el => (linkRefs.current[i] = el)}
+              style={{ outline: 'none' }}
+              tabIndex={-1}
             >
               <span className="material-symbols-outlined">{item.icon}</span>
               {item.title}

--- a/src/shared/Sidebar.jsx
+++ b/src/shared/Sidebar.jsx
@@ -61,7 +61,13 @@ export default function Sidebar({ onOpenChange }) {
               className={`flex gap-x-2 border-l-4 px-5 py-5 text-foreground-2 transition-all hover:border-foreground-2 hover:bg-default/50 hover:text-foreground-1 hover:opacity-100 focus:border-foreground-1 focus:bg-default focus:text-foreground-1 focus:outline-none focus:ring-0 ${selected}`}
               href={item.href}
               key={`nav-item-${i}`}
-              onPress={() => {
+              onPress={e => {
+                if (e.ctrlKey || e.metaKey || e.button === 1) {
+                  return;
+                  // this checks if the user is holding Ctrl, Cmd, or is middle - clicking and would open a new tab
+                }
+                // for normal single click
+                e.preventDefault();
                 navigate(item.href);
                 if (onOpenChange) {
                   onOpenChange(false);


### PR DESCRIPTION
On Issue #167 

Made the following changes:

- Implemented keyboard navigation using `Spacebar` to focus on links and `Enter` to activate them.
- Added logic to retain default link behaviour for opening in a new tab, while handling single-click navigation.
- Updated the focus styles to provide clear and consistent outlines on focused elements.

These changes significantly improve the accessibility and usability of the sidebar navigation, ensuring a better experience for all users, including those relying on keyboard navigation and assistive technologies