### PR TITLE
Fix search debounce

### DIFF
--- a/src/shared/hooks/useDebouncedSearch.jsx
+++ b/src/shared/hooks/useDebouncedSearch.jsx
@@ -1,23 +1,25 @@
 import { useEffect, useState } from 'react';
 
-const useDebouncedSearch = (value, delay) => {
+export default function useDebouncedSearch(value, delay) {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
-  const validateSearchTerm = query => {
-    return query.length === 0 || query.length >= 3;
-  };
-
   useEffect(() => {
-    const handler = setTimeout(() => {
-      if (validateSearchTerm(value)) setDebouncedValue(value);
-    }, delay);
+    let timeout;
+
+    if (validateSearchTerm(value)) {
+      timeout = setTimeout(() => setDebouncedValue(value), delay);
+    }
 
     return () => {
-      clearTimeout(handler);
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
     };
   }, [value, delay]);
 
   return debouncedValue;
-};
+}
 
-export default useDebouncedSearch;
+const validateSearchTerm = query =>
+  (query?.length ?? 0) === 0 || query.length >= 3;


### PR DESCRIPTION
Fixed AVS search debounce not to make many requests in a row when search parameters changed. This has been caused by incorrect dependency configuration in `useEffect`. Therefore, `useEffect` is now split into 2 different ones with different set of dependencies.

The fix should be applied to other views as well.