### PR TITLE
Feat/enable dev on demand branch

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,21 @@
+name: Deploy to Amplify Stage
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: Git ref
+        default: dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: deploy
+      run: |
+          URL="${{ secrets.AMPLIFY_WEBHOOK_DEV }}"
+          curl -X POST -d {} "$URL" -H "Content-Type: application/json"

--- a/terraform/Amplify/main.tf
+++ b/terraform/Amplify/main.tf
@@ -20,10 +20,22 @@ resource "aws_amplify_app" "main" {
 
 resource "aws_amplify_branch" "main" {
   app_id      = aws_amplify_app.main.id
-  branch_name = "main"
+  branch_name = var.main_branch
   stage       = "PRODUCTION"
 
   enable_auto_build = false
+}
+
+resource "aws_amplify_branch" "dev" {
+  app_id = aws_amplify_app.main.id
+  branch_name = var.dev_branch
+  stage       = "DEVELOPMENT"
+
+  environment_variables = {
+    NODE_ENV = "development"
+  }
+
+  enable_auto_build = true
 }
 
 resource "aws_amplify_domain_association" "main" {
@@ -37,8 +49,19 @@ resource "aws_amplify_domain_association" "main" {
     branch_name = aws_amplify_branch.main.branch_name
     prefix      = "stage"
   }
-}
 
+  # https://dev.restaking.info
+  sub_domain {
+    branch_name = aws_amplify_branch.main.branch_name
+    prefix      = "prod"
+  }
+
+  # https://dev.restaking.info
+  sub_domain {
+    branch_name = aws_amplify_branch.dev.branch_name
+    prefix      = "dev"
+  }
+}
 
 resource "aws_amplify_webhook" "stage" {
   app_id      = aws_amplify_app.main.id
@@ -46,3 +69,27 @@ resource "aws_amplify_webhook" "stage" {
   description = "stage"
 }
 
+resource "aws_amplify_webhook" "dev" {
+  app_id      = aws_amplify_app.main.id
+  branch_name = aws_amplify_branch.dev.branch_name
+  description = "development"
+}
+
+
+
+output "amplify_app_id" {
+  value = aws_amplify_app.main.id
+}
+
+output "amplify_app_url" {
+  value = aws_amplify_domain_association.main.sub_domain
+}
+
+output "aws_amplify_webhook_stage" {
+  value = aws_amplify_webhook.stage
+}
+
+
+output "aws_amplify_webhook_dev" {
+  value = aws_amplify_webhook.dev
+}

--- a/terraform/Amplify/main.tf
+++ b/terraform/Amplify/main.tf
@@ -50,7 +50,7 @@ resource "aws_amplify_domain_association" "main" {
     prefix      = "stage"
   }
 
-  # https://dev.restaking.info
+  # https://prod.restaking.info
   sub_domain {
     branch_name = aws_amplify_branch.main.branch_name
     prefix      = "prod"

--- a/terraform/Amplify/variables.tf
+++ b/terraform/Amplify/variables.tf
@@ -1,0 +1,12 @@
+variable "main_branch" {
+  description = "The branch name for the AWS Amplify stage environment"
+  type        = string
+  default     = "main"  # You can set a default value or leave it empty
+}
+
+
+variable "dev_branch" {
+  description = "The branch name for the AWS Amplify deployment"
+  type        = string
+  default     = "dev"  # You can set a default value or leave it empty
+}


### PR DESCRIPTION
Hi Ruben, 

Given the need for developers to deploy the frontend by specific branches on demand, achieving this without Terraform and DNS changes can be challenging. However, I've identified a workaround that can meet the requirement:

1. Enable the dev Branch: Ensure the dev branch is set up and active in AWS Amplify. **- Done** 
2. Create the Subdomain dev.restaking.info: Set up the subdomain to point to your AWS Amplify app. **-Done**
3. Update Terraform Code: Make the necessary adjustments to your Terraform code to configure the subdomain and branch, then run the Terraform deployment once. **-Done**
3. Enable a Webhook on the dev Branch: Set up a webhook to automatically trigger deployments whenever changes are pushed to the dev branch. **-Done**

With this setup, developers only need to merge code changes into the dev branch. The dev branch will automatically deploy to AWS Amplify whenever updates occur. If there are conflicts or issues on the dev branch, simply delete the branch and recreate it from the desired on-demand branch.

Please help to review and approve this PR.