### PR TITLE
GET /avs endpoints now return values in ETH instead of gwei

### DIFF
--- a/src/avs/AVSDetails.jsx
+++ b/src/avs/AVSDetails.jsx
@@ -39,11 +39,11 @@ export default function AVSDetails() {
         const avs = await avsService.getAVSDetails(address);
 
         const strategies = avs.strategies.reduce((acc, strategy) => {
-          acc[strategy.address] = BigInt(strategy.tokens) / BigInt(1e18);
+          acc[strategy.address] = strategy.tokens;
           return acc;
         }, Object.create(null));
 
-        const totals = { lst: 0n, eth: 0n, eigen: 0n };
+        const totals = { lst: 0, eth: 0, eigen: 0 };
 
         for (const strategy in strategies) {
           if (strategy === EIGEN_STRATEGY) {


### PR DESCRIPTION
otherwise https://stage.restaking.info/avs/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0 crashes