### PR TITLE
Fix LST/LRT page crashing due to undefined

### DIFF
--- a/src/lrt/LRT.jsx
+++ b/src/lrt/LRT.jsx
@@ -87,5 +87,5 @@ const getNumberOfLRT = data => {
   }
 
   // converted by transformProtocols, is now an object
-  return Object.keys(data[latest].protocols).length;
+  return Object.keys(latest.protocols).length;
 };

--- a/src/lst/LST.jsx
+++ b/src/lst/LST.jsx
@@ -111,5 +111,5 @@ const getNumberOfLST = data => {
 
   const latest = data[data.length - 1];
 
-  return data[latest].strategies?.length ?? 0;
+  return latest.strategies?.length ?? 0;
 };


### PR DESCRIPTION
`latest` is already an object