### PR TITLE
Add promoted operators

### DIFF
--- a/src/@services/RestakingDashboardService.js
+++ b/src/@services/RestakingDashboardService.js
@@ -1,0 +1,13 @@
+import BaseService from './BaseService';
+
+export default class RestakingDashboardService extends BaseService {
+  async getPromotedOperators() {
+    const response = await BaseService._get('/rd/promotion/operators');
+
+    if (response.ok) {
+      return await response.json();
+    }
+
+    throw await this._createError(response);
+  }
+}

--- a/src/@services/RestakingDashboardService.js
+++ b/src/@services/RestakingDashboardService.js
@@ -10,4 +10,16 @@ export default class RestakingDashboardService extends BaseService {
 
     throw await this._createError(response);
   }
+
+  async getAVSPromotedOperators(address) {
+    const response = await BaseService._get(
+      `/rd/promotion/avs/${address}/operators`
+    );
+
+    if (response.ok) {
+      return await response.json();
+    }
+
+    throw await this._createError(response);
+  }
 }

--- a/src/@services/ServiceContext.jsx
+++ b/src/@services/ServiceContext.jsx
@@ -3,6 +3,7 @@ import AVSService from './AVSService';
 import EigenLayerService from './EigenLayerService';
 import LRTService from './LRTService';
 import OperatorService from './OperatorService';
+import RestakingDashboardService from './RestakingDashboardService';
 
 export const ServiceContext = createContext();
 
@@ -21,5 +22,6 @@ const services = {
   avsService: new AVSService(),
   lrtService: new LRTService(),
   operatorService: new OperatorService(),
-  eigenlayerService: new EigenLayerService()
+  eigenlayerService: new EigenLayerService(),
+  rdService: new RestakingDashboardService()
 };

--- a/src/avs/AVSDetailsOperatorsTab.jsx
+++ b/src/avs/AVSDetailsOperatorsTab.jsx
@@ -252,7 +252,7 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
   const renderPromotedOperators = useCallback(() => {
     return state.promotedOperators?.map((operator, i) => (
       <TableRow
-        className="max-h-16 min-h-16 cursor-pointer border-t border-outline bg-black/100 transition-colors hover:bg-default"
+        className="size-16 cursor-pointer border-t border-outline bg-black/100 transition-colors hover:bg-default"
         key={`promoted-operator-item-${i}`}
         onClick={() =>
           navigate(`/operators/${operator.address}`, {
@@ -356,15 +356,7 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
               TVL
             </TableColumn>
           </TableHeader>
-          <TableBody
-            emptyContent={
-              <div className="flex h-[40rem] flex-col items-center justify-center">
-                <span className="text-lg text-foreground-2">
-                  No result found for {truncate(state.search ?? '')}
-                </span>
-              </div>
-            }
-          >
+          <TableBody>
             {searchParams.get('page') === '1' && renderPromotedOperators()}
 
             {(state.isTableLoading || isAVSLoading) &&
@@ -428,6 +420,22 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
                   </TableCell>
                 </TableRow>
               ))}
+
+            {!state.isTableLoading &&
+              !isAVSLoading &&
+              state.operators.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <div className="flex h-[40rem] flex-col items-center justify-center">
+                      <span className="text-lg text-foreground-2">
+                        No result found for {truncate(state.search ?? '')}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell hidden />
+                  <TableCell hidden />
+                </TableRow>
+              )}
 
             {!state.isTableLoading &&
               !isAVSLoading &&

--- a/src/avs/AVSDetailsOperatorsTab.jsx
+++ b/src/avs/AVSDetailsOperatorsTab.jsx
@@ -222,7 +222,7 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
           promotedOperatorsRate: response.rate
         });
       } catch (e) {
-        //TODO: handle error
+        // swallow error because we don't need to show error message
       }
     })();
   }, [address, dispatch, rdService]);

--- a/src/avs/AVSDetailsOperatorsTab.jsx
+++ b/src/avs/AVSDetailsOperatorsTab.jsx
@@ -112,6 +112,7 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
     error: undefined,
     operators: [],
     promotedOperators: [],
+    promotedOperatorsRate: 1,
     isInputTouched: false,
     isTableLoading: true,
     totalPages: undefined,
@@ -217,7 +218,8 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
       try {
         const response = await rdService.getAVSPromotedOperators(address);
         dispatch({
-          promotedOperators: response.results
+          promotedOperators: response.results,
+          promotedOperatorsRate: response.rate
         });
       } catch (e) {
         //TODO: handle error
@@ -280,14 +282,16 @@ function AVSOperatorsList({ address, avsError, isAVSLoading, tvl }) {
             : `${((operator.strategiesTotal / tvl) * 100).toFixed(2)}%`}
         </TableCell>
         <TableCell className="pe-8 text-end">
-          <div>{formatUSD(operator.strategiesTotal * state.currentRate)}</div>
+          <div>
+            {formatUSD(operator.strategiesTotal * state.promotedOperatorsRate)}
+          </div>
           <div className="text-xs text-foreground-2">
             {formatETH(operator.strategiesTotal)}
           </div>
         </TableCell>
       </TableRow>
     ));
-  }, [navigate, state.currentRate, state.promotedOperators, tvl]);
+  }, [navigate, state.promotedOperators, state.promotedOperatorsRate, tvl]);
 
   return (
     <div className="rd-box text-sm">

--- a/src/operators/OperatorList.jsx
+++ b/src/operators/OperatorList.jsx
@@ -47,6 +47,7 @@ export default function OperatorList() {
   const [state, dispatch] = useMutativeReducer(reduceState, {
     operators: [],
     promotedOperators: [],
+    promotedOperatorsRate: 1,
     isFetchingData: false,
     searchTerm: searchParams.get('search'),
     error: null,
@@ -106,7 +107,8 @@ export default function OperatorList() {
       try {
         const response = await rdService.getPromotedOperators();
         dispatch({
-          promotedOperators: response.results
+          promotedOperators: response.results,
+          promotedOperatorsRate: response.rate
         });
       } catch (e) {
         //TODO: handle error
@@ -188,14 +190,16 @@ export default function OperatorList() {
           {formatNumber(operator.stakerCount)}
         </TableCell>
         <TableCell className="pe-8 text-end">
-          <div>{formatUSD(operator.strategiesTotal * state.rate)}</div>
+          <div>
+            {formatUSD(operator.strategiesTotal * state.promotedOperatorsRate)}
+          </div>
           <div className="text-xs text-foreground-2">
             {formatETH(operator.strategiesTotal)}
           </div>
         </TableCell>
       </TableRow>
     ));
-  }, [navigate, state.promotedOperators, state.rate]);
+  }, [navigate, state.promotedOperators, state.promotedOperatorsRate]);
 
   return (
     <div className="flex h-full flex-col">

--- a/src/operators/OperatorList.jsx
+++ b/src/operators/OperatorList.jsx
@@ -40,12 +40,13 @@ const columns = [
 ];
 
 export default function OperatorList() {
-  const { operatorService } = useServices();
+  const { operatorService, rdService } = useServices();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const abortController = useRef(null);
   const [state, dispatch] = useMutativeReducer(reduceState, {
     operators: [],
+    promotedOperators: [],
     isFetchingData: false,
     searchTerm: searchParams.get('search'),
     error: null,
@@ -100,6 +101,19 @@ export default function OperatorList() {
     [operatorService, dispatch]
   );
 
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await rdService.getPromotedOperators();
+        dispatch({
+          promotedOperators: response.results
+        });
+      } catch (e) {
+        //TODO: handle error
+      }
+    })();
+  }, [dispatch, rdService]);
+
   const handlePageClick = useCallback(
     page => {
       setSearchParams({ page });
@@ -144,6 +158,44 @@ export default function OperatorList() {
       dispatch({ searchTriggered: true });
     }
   }, [dispatch, debouncedSearchTerm]);
+
+  const renderPromotedOperators = useCallback(() => {
+    return state.promotedOperators?.map((operator, i) => (
+      <TableRow
+        className="max-h-16 min-h-16 cursor-pointer border-t border-outline bg-black/100 transition-colors hover:bg-default"
+        key={`promoted-operator-item-${i}`}
+        onClick={() =>
+          navigate(`/operators/${operator.address}`, {
+            state: { operator }
+          })
+        }
+      >
+        <TableCell className="p-4">
+          <div className="flex items-center gap-x-3">
+            <div className="flex size-5 items-center justify-center rounded-md bg-foreground-2 p-1 text-center text-xs text-content1">
+              ad
+            </div>
+            <ThirdPartyLogo
+              className="size-8 min-w-8"
+              url={operator.metadata?.logo}
+            />
+            <span className="truncate">
+              {operator.metadata?.name || operator.address}
+            </span>
+          </div>
+        </TableCell>
+        <TableCell className="pe-8 text-end">
+          {formatNumber(operator.stakerCount)}
+        </TableCell>
+        <TableCell className="pe-8 text-end">
+          <div>{formatUSD(operator.strategiesTotal * state.rate)}</div>
+          <div className="text-xs text-foreground-2">
+            {formatETH(operator.strategiesTotal)}
+          </div>
+        </TableCell>
+      </TableRow>
+    ));
+  }, [navigate, state.promotedOperators, state.rate]);
 
   return (
     <div className="flex h-full flex-col">
@@ -195,7 +247,11 @@ export default function OperatorList() {
               table: state.operators?.length === 0 ? 'h-full' : null,
               thead: '[&>tr:last-child]:hidden'
             }}
-            hideHeader={!state.isFetchingData && state.operators.length == 0}
+            hideHeader={
+              state.promotedOperators.length === 0 &&
+              !state.isFetchingData &&
+              state.operators.length == 0
+            }
             layout="fixed"
             onSortChange={e => dispatch({ sortDescriptor: e })}
             removeWrapper
@@ -212,19 +268,9 @@ export default function OperatorList() {
                 </TableColumn>
               )}
             </TableHeader>
-            <TableBody
-              emptyContent={
-                <div className="flex flex-col items-center justify-center">
-                  <span className="text-lg text-foreground-2">
-                    No operator found for &quot;
-                    {debouncedSearchTerm.length > 42
-                      ? `${debouncedSearchTerm.substring(0, 42)}...`
-                      : debouncedSearchTerm}
-                    &quot;
-                  </span>
-                </div>
-              }
-            >
+            <TableBody>
+              {searchParams.get('page') === '1' && renderPromotedOperators()}
+
               {state.isFetchingData
                 ? [...Array(10)].map((_, i) => (
                     <TableRow className="border-t border-outline" key={i}>
@@ -276,6 +322,24 @@ export default function OperatorList() {
                       </TableCell>
                     </TableRow>
                   ))}
+
+              {!state.isFetchingData && state.operators.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <div className="flex flex-col items-center justify-center">
+                      <span className="text-lg text-foreground-2">
+                        No operator found for &quot;
+                        {debouncedSearchTerm.length > 42
+                          ? `${debouncedSearchTerm.substring(0, 42)}...`
+                          : debouncedSearchTerm}
+                        &quot;
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell />
+                  <TableCell />
+                </TableRow>
+              )}
             </TableBody>
           </Table>
           {state.totalPages > 1 && (

--- a/src/operators/OperatorList.jsx
+++ b/src/operators/OperatorList.jsx
@@ -162,7 +162,7 @@ export default function OperatorList() {
   const renderPromotedOperators = useCallback(() => {
     return state.promotedOperators?.map((operator, i) => (
       <TableRow
-        className="max-h-16 min-h-16 cursor-pointer border-t border-outline bg-black/100 transition-colors hover:bg-default"
+        className="size-16 cursor-pointer border-t border-outline bg-black/100 transition-colors hover:bg-default"
         key={`promoted-operator-item-${i}`}
         onClick={() =>
           navigate(`/operators/${operator.address}`, {
@@ -336,8 +336,8 @@ export default function OperatorList() {
                       </span>
                     </div>
                   </TableCell>
-                  <TableCell />
-                  <TableCell />
+                  <TableCell hidden />
+                  <TableCell hidden />
                 </TableRow>
               )}
             </TableBody>

--- a/src/operators/OperatorList.jsx
+++ b/src/operators/OperatorList.jsx
@@ -111,7 +111,7 @@ export default function OperatorList() {
           promotedOperatorsRate: response.rate
         });
       } catch (e) {
-        //TODO: handle error
+        // swallow error because we don't need to show error message
       }
     })();
   }, [dispatch, rdService]);


### PR DESCRIPTION
Two pages with slightly different information displayed:
1. `/operators`
2. `/avs/:address/operators`

Some edge cases to consider:
1. When we search for operators, we should always display the ads even if the result is empty.
2. In `/avs/:address/operators`, it is ok to not show promoted operators if they are not currently securing the AVS
3. If the promoted operators endpoint fails, we don't need to display error.

Backend PR:
https://github.com/NethermindEth/restaking-dashboard-backend/pull/114