### PR TITLE
Integrate Clerk with backend services

### DIFF
--- a/src/@services/AVSService.js
+++ b/src/@services/AVSService.js
@@ -1,9 +1,13 @@
 import BaseService from './BaseService';
 
 export default class AVSService extends BaseService {
+  constructor(context) {
+    super(context);
+  }
+
   async getAll(pageNumber, pageSize = 10, search, sort, signal) {
     const pageIndex = Math.max(0, pageNumber - 1);
-    const response = await BaseService._get('/avs', {
+    const response = await this._get('/avs', {
       query: { 'page-index': pageIndex, 'page-size': pageSize, search, sort },
       signal
     });
@@ -16,7 +20,7 @@ export default class AVSService extends BaseService {
   }
 
   async getAVSDetails(address) {
-    const response = await BaseService._get(`/avs/${address}`);
+    const response = await this._get(`/avs/${address}`);
 
     if (response.ok) {
       return await response.json();
@@ -27,7 +31,7 @@ export default class AVSService extends BaseService {
 
   async getAVSOperators(address, pageNumber, search, sort, signal) {
     const pageIndex = Math.max(0, pageNumber - 1);
-    const response = await BaseService._get(`/avs/${address}/operators`, {
+    const response = await this._get(`/avs/${address}/operators`, {
       query: {
         'page-index': pageIndex,
         search,
@@ -44,7 +48,7 @@ export default class AVSService extends BaseService {
   }
 
   async getAVSTotalValue(address) {
-    const response = await BaseService._get(`/avs/${address}/tvl`);
+    const response = await this._get(`/avs/${address}/tvl`);
 
     if (response.ok) {
       return await response.json();
@@ -54,9 +58,7 @@ export default class AVSService extends BaseService {
   }
 
   async getAVSOperatorsOvertime(address) {
-    const response = await BaseService._get(
-      `/avs/${address}/operators/over-time`
-    );
+    const response = await this._get(`/avs/${address}/operators/over-time`);
 
     if (response.ok) {
       return await response.json();

--- a/src/@services/BaseService.js
+++ b/src/@services/BaseService.js
@@ -1,5 +1,15 @@
 export default class BaseService {
-  static async #call(endpoint, options) {
+  #context;
+
+  constructor(context) {
+    if (!context) {
+      throw new Error('`context` is required');
+    }
+
+    this.#context = context;
+  }
+
+  async #call(endpoint, options) {
     const url = new URL(
       `${endpoint.startsWith('/') ? '' : '/'}${endpoint}`,
       import.meta.env.VITE_API_BASE_URL
@@ -22,7 +32,7 @@ export default class BaseService {
     const request = {
       credentials: 'include',
       headers: {
-        Accept: 'application/json',
+        accept: 'application/json',
         'accept-language': 'en-us',
         'content-type': `application/json; charset=utf-8`,
         ...options?.headers
@@ -30,6 +40,14 @@ export default class BaseService {
       method: options?.method?.toUpperCase() || 'get',
       signal: options?.signal
     };
+
+    if (this.#context.session) {
+      const token = await this.#context.session.getToken();
+
+      if (token) {
+        request.headers.authorization = `Bearer ${token}`;
+      }
+    }
 
     if (options?.body != null) {
       const isFormData = options.body instanceof FormData;
@@ -62,7 +80,7 @@ export default class BaseService {
    * @param {{body: object, headers: object, query: object}?} options
    * @returns {Promise<Response>}
    */
-  static _delete(endpoint, options) {
+  _delete(endpoint, options) {
     return this.#call(endpoint, { ...options, method: 'delete' });
   }
 
@@ -72,7 +90,7 @@ export default class BaseService {
    * @param {{body: object, headers: object, query: object}?} options
    * @returns {Promise<Response>}
    */
-  static _get(endpoint, options) {
+  _get(endpoint, options) {
     return this.#call(endpoint, { ...options, method: 'get' });
   }
 
@@ -82,7 +100,7 @@ export default class BaseService {
    * @param {{body: object, headers: object, query: object}?} options
    * @returns {Promise<Response>}
    */
-  static _patch(endpoint, options) {
+  _patch(endpoint, options) {
     return this.#call(endpoint, { ...options, method: 'patch' });
   }
 
@@ -92,7 +110,7 @@ export default class BaseService {
    * @param {{body: object, headers: object, query: object}?} options
    * @returns {Promise<Response>}
    */
-  static _post(endpoint, options) {
+  _post(endpoint, options) {
     return this.#call(endpoint, { ...options, method: 'post' });
   }
 
@@ -102,7 +120,7 @@ export default class BaseService {
    * @param {{body: object, headers: object, query: object}?} options
    * @returns {Promise<Response>}
    */
-  static _put(endpoint, options) {
+  _put(endpoint, options) {
     return this.#call(endpoint, { ...options, method: 'put' });
   }
 

--- a/src/@services/EigenLayerService.js
+++ b/src/@services/EigenLayerService.js
@@ -1,8 +1,12 @@
 import BaseService from './BaseService';
 
 export default class EigenLayerService extends BaseService {
+  constructor(context) {
+    super(context);
+  }
+
   async getEigenLayerTVLOvertime() {
-    const response = await BaseService._get(`/eigenlayer/tvl`);
+    const response = await this._get(`/eigenlayer/tvl`);
 
     if (response.ok) {
       return await response.json();
@@ -12,7 +16,7 @@ export default class EigenLayerService extends BaseService {
   }
 
   async getEigenLayerLSTTotalValue() {
-    const response = await BaseService._get(`/eigenlayer/tvl/lst`);
+    const response = await this._get(`/eigenlayer/tvl/lst`);
 
     if (response.ok) {
       return await response.json();

--- a/src/@services/LRTService.js
+++ b/src/@services/LRTService.js
@@ -1,8 +1,12 @@
 import BaseService from './BaseService';
 
 export default class LRTService extends BaseService {
+  constructor(context) {
+    super(context);
+  }
+
   async getAll() {
-    const response = await BaseService._get('/lrt/all');
+    const response = await this._get('/lrt/all');
 
     if (response.ok) {
       return await response.json();
@@ -12,7 +16,7 @@ export default class LRTService extends BaseService {
   }
 
   async getLatestDelegations() {
-    const response = await BaseService._get('/lrt/delegations/latest');
+    const response = await this._get('/lrt/delegations/latest');
 
     if (response.ok) {
       return await response.json();
@@ -22,7 +26,7 @@ export default class LRTService extends BaseService {
   }
 
   async getLatest() {
-    const response = await BaseService._get('/lrt/latest');
+    const response = await this._get('/lrt/latest');
 
     if (response.ok) {
       return await response.json();

--- a/src/@services/OperatorService.js
+++ b/src/@services/OperatorService.js
@@ -1,9 +1,13 @@
 import BaseService from './BaseService';
 
 export default class OperatorService extends BaseService {
+  constructor(context) {
+    super(context);
+  }
+
   async getAll(pageNumber, pageSize = 10, search, sort, signal) {
     const pageIndex = Math.max(0, pageNumber - 1);
-    const response = await BaseService._get(`operators`, {
+    const response = await this._get(`operators`, {
       query: {
         'page-index': pageIndex,
         'page-size': pageSize,
@@ -21,7 +25,7 @@ export default class OperatorService extends BaseService {
   }
 
   async getOperator(address) {
-    const response = await BaseService._get(`operators/${address}`);
+    const response = await this._get(`operators/${address}`);
 
     if (response.ok) {
       return await response.json();
@@ -31,7 +35,7 @@ export default class OperatorService extends BaseService {
   }
 
   async getOperatorTVL(address) {
-    const response = await BaseService._get(`operators/${address}/tvl`);
+    const response = await this._get(`operators/${address}/tvl`);
 
     if (response.ok) {
       return await response.json();
@@ -41,7 +45,7 @@ export default class OperatorService extends BaseService {
   }
 
   async getRestakerTrend(address) {
-    const response = await BaseService._get(`operators/${address}/restakers`);
+    const response = await this._get(`operators/${address}/restakers`);
 
     if (response.ok) {
       return await response.json();

--- a/src/@services/RestakingDashboardService.js
+++ b/src/@services/RestakingDashboardService.js
@@ -1,8 +1,12 @@
 import BaseService from './BaseService';
 
 export default class RestakingDashboardService extends BaseService {
+  constructor(context) {
+    super(context);
+  }
+
   async getPromotedOperators() {
-    const response = await BaseService._get('/rd/promotion/operators');
+    const response = await this._get('/rd/promotion/operators');
 
     if (response.ok) {
       return await response.json();
@@ -12,9 +16,7 @@ export default class RestakingDashboardService extends BaseService {
   }
 
   async getAVSPromotedOperators(address) {
-    const response = await BaseService._get(
-      `/rd/promotion/avs/${address}/operators`
-    );
+    const response = await this._get(`/rd/promotion/avs/${address}/operators`);
 
     if (response.ok) {
       return await response.json();

--- a/src/@services/ServiceContext.jsx
+++ b/src/@services/ServiceContext.jsx
@@ -1,9 +1,10 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect } from 'react';
 import AVSService from './AVSService';
 import EigenLayerService from './EigenLayerService';
 import LRTService from './LRTService';
 import OperatorService from './OperatorService';
 import RestakingDashboardService from './RestakingDashboardService';
+import { useSession } from '@clerk/clerk-react';
 
 export const ServiceContext = createContext();
 
@@ -11,6 +12,12 @@ export const ServiceContext = createContext();
 export const useServices = () => useContext(ServiceContext);
 
 export function ServiceProvider({ children }) {
+  const { session } = useSession();
+
+  useEffect(() => {
+    context.session = session;
+  }, [session]);
+
   return (
     <ServiceContext.Provider value={services}>
       {children}
@@ -18,10 +25,11 @@ export function ServiceProvider({ children }) {
   );
 }
 
+const context = {};
 const services = {
-  avsService: new AVSService(),
-  lrtService: new LRTService(),
-  operatorService: new OperatorService(),
-  eigenlayerService: new EigenLayerService(),
-  rdService: new RestakingDashboardService()
+  avsService: new AVSService(context),
+  lrtService: new LRTService(context),
+  operatorService: new OperatorService(context),
+  eigenlayerService: new EigenLayerService(context),
+  rdService: new RestakingDashboardService(context)
 };

--- a/src/shared/Layout.jsx
+++ b/src/shared/Layout.jsx
@@ -2,10 +2,22 @@ import Footer from './Footer';
 import Header from './Header';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
+import { Spinner } from '@nextui-org/react';
+import { useSession } from '@clerk/clerk-react';
 import { useTailwindBreakpoint } from './hooks/useTailwindBreakpoint';
 
 export default function Layout() {
   const showSidebar = useTailwindBreakpoint('lg');
+  const { isLoaded } = useSession();
+
+  // Don't render the main content until the auth session is loaded
+  if (!isLoaded) {
+    return (
+      <div className="flex h-screen flex-col content-center justify-center">
+        <Spinner color="primary" size="lg" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen flex-col gap-4 bg-background text-foreground">


### PR DESCRIPTION
Updated backend services with Clerk session data. They now send the session token automatically if any. The UI has been modified so that it does not render while the Clerk is initializing to avoid sending irrelevant info to the server.

Requires https://github.com/NethermindEth/restaking-dashboard-backend/pull/118